### PR TITLE
Refactor utils and add xml2{list,dict} with quick regression tests

### DIFF
--- a/datasets/tests/test.xml
+++ b/datasets/tests/test.xml
@@ -1,0 +1,44 @@
+<annotation>
+	<folder>VOC2007</folder>
+	<filename>000001.jpg</filename>
+	<source>
+		<database>The VOC2007 Database</database>
+		<annotation>PASCAL VOC2007</annotation>
+		<image>flickr</image>
+		<flickrid>341012865</flickrid>
+	</source>
+	<owner>
+		<flickrid>Fried Camels</flickrid>
+		<name>Jinky the Fruit Bat</name>
+	</owner>
+	<size>
+		<width>353</width>
+		<height>500</height>
+		<depth>3</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>dog</name>
+		<pose>Left</pose>
+		<truncated>1</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>48</xmin>
+			<ymin>240</ymin>
+			<xmax>195</xmax>
+			<ymax>371</ymax>
+		</bndbox>
+	</object>
+	<object>
+		<name>person</name>
+		<pose>Left</pose>
+		<truncated>1</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>8</xmin>
+			<ymin>12</ymin>
+			<xmax>352</xmax>
+			<ymax>498</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/datasets/tests/test_xml2x.py
+++ b/datasets/tests/test_xml2x.py
@@ -1,0 +1,53 @@
+from ..utils import get_my_path, xml2list, xml2dict
+from os import path
+
+MY_PATH = get_my_path()
+
+
+def test_xml2list_voc07():
+    gt = ['VOC2007',
+          '000001.jpg',
+          {'annotation': 'PASCAL VOC2007',
+           'database': 'The VOC2007 Database',
+           'flickrid': '341012865',
+           'image': 'flickr'},
+          {'flickrid': 'Fried Camels', 'name': 'Jinky the Fruit Bat'},
+          {'depth': '3', 'height': '500', 'width': '353'},
+          '0',
+          {'bndbox': {'xmax': '195', 'xmin': '48', 'ymax': '371', 'ymin': '240'},
+           'difficult': '0',
+           'name': 'dog',
+           'pose': 'Left',
+           'truncated': '1'},
+          {'bndbox': {'xmax': '352', 'xmin': '8', 'ymax': '498', 'ymin': '12'},
+           'difficult': '0',
+           'name': 'person',
+           'pose': 'Left',
+           'truncated': '1'}]
+    xml_filename = path.join(MY_PATH, 'test.xml')
+    gv = xml2list(xml_filename)
+    assert gt == gv
+
+
+def test_xml2dict_voc07():
+    gt = {'filename': '000001.jpg',
+          'folder': 'VOC2007',
+          'object': {'bndbox': {'xmax': '352',
+                                'xmin': '8',
+                                'ymax': '498',
+                                'ymin': '12'},
+                     'difficult': '0',
+                     'name': 'person',
+                     'pose': 'Left',
+                     'truncated': '1'},
+          'owner': {'flickrid': 'Fried Camels', 'name': 'Jinky the Fruit Bat'},
+          'segmented': '0',
+          'size': {'depth': '3', 'height': '500', 'width': '353'},
+          'source': {'annotation': 'PASCAL VOC2007',
+                     'database': 'The VOC2007 Database',
+                     'flickrid': '341012865',
+                     'image': 'flickr'}}
+    # WARNING: when using xml2dict, only one object will show up!
+    xml_filename = path.join(MY_PATH, 'test.xml')
+    gv = xml2dict(xml_filename)
+    assert gt == gv

--- a/datasets/utils/__init__.py
+++ b/datasets/utils/__init__.py
@@ -1,3 +1,7 @@
+from my_path import get_my_path, get_my_path_basename
+from xml2x import xml2dict, xml2list
+
+# -- old utils.py
 import numpy as np
 import scipy.sparse as sp
 import warnings
@@ -27,9 +31,9 @@ def as_float_array(X, overwrite_X=False):
     """
     Converts a numpy array to type np.float
 
-    The new dtype will be float32 or np.float64, depending on the original type.
-    The function can create a copy or modify the argument depending
-    of the argument overwrite_X
+    The new dtype will be float32 or np.float64, depending on the original
+    type.  The function can create a copy or modify the argument depending of
+    the argument overwrite_X
 
     WARNING : If X is not of type float, then a copy of X with the right type
               will be returned
@@ -197,6 +201,7 @@ class deprecated(object):
 
         # FIXME: we should probably reset __new__ for full generality
         init = cls.__init__
+
         def wrapped(*args, **kwargs):
             warnings.warn(msg, category=DeprecationWarning)
             return init(*args, **kwargs)

--- a/datasets/utils/my_path.py
+++ b/datasets/utils/my_path.py
@@ -1,0 +1,23 @@
+from os import path
+
+__all__ = ['get_my_path',
+           'get_my_path_basename',
+          ]
+
+
+def get_my_path(my_file=None):
+    if my_file is None:
+        import inspect
+        caller = inspect.currentframe().f_back
+        my_file = caller.f_globals['__file__']
+    return path.dirname(path.abspath(my_file))
+
+
+def get_my_path_basename(my_file=None):
+    if my_file is None:
+        import inspect
+        caller = inspect.currentframe().f_back
+        my_file = caller.f_globals['__file__']
+    dirname = path.dirname(path.abspath(my_file))
+    basename = path.basename(dirname)
+    return basename

--- a/datasets/utils/xml2x.py
+++ b/datasets/utils/xml2x.py
@@ -1,0 +1,82 @@
+# WARNING: this module is *not* bullet proof !
+
+from xml.etree import ElementTree
+
+
+class XmlListConfig(list):
+    # from http://code.activestate.com/recipes/410469-xml-as-dictionary
+    def __init__(self, aList):
+        for element in aList:
+            if element:
+                # treat like dict
+                if len(element) == 1 or element[0].tag != element[1].tag:
+                    self.append(XmlDictConfig(element))
+                # treat like list
+                elif element[0].tag == element[1].tag:
+                    self.append(XmlListConfig(element))
+            elif element.text:
+                text = element.text.strip()
+                if text:
+                    self.append(text)
+
+
+class XmlDictConfig(dict):
+    # from http://code.activestate.com/recipes/410469-xml-as-dictionary
+    '''
+    Example usage:
+
+    >>> tree = ElementTree.parse('your_file.xml')
+    >>> root = tree.getroot()
+    >>> xmldict = XmlDictConfig(root)
+
+    Or, if you want to use an XML string:
+
+    >>> root = ElementTree.XML(xml_string)
+    >>> xmldict = XmlDictConfig(root)
+
+    And then use xmldict for what it is... a dict.
+    '''
+    def __init__(self, parent_element):
+        if parent_element.items():
+            self.update(dict(parent_element.items()))
+        for element in parent_element:
+            if element:
+                # treat like dict - we assume that if the first two tags
+                # in a series are different, then they are all different.
+                if len(element) == 1 or element[0].tag != element[1].tag:
+                    aDict = XmlDictConfig(element)
+                # treat like list - we assume that if the first two tags
+                # in a series are the same, then the rest are the same.
+                else:
+                    # here, we put the list in dictionary; the key is the
+                    # tag name the list elements all share in common, and
+                    # the value is the list itself
+                    aDict = {element[0].tag: XmlListConfig(element)}
+                # if the tag has attributes, add those to the dict
+                if element.items():
+                    aDict.update(dict(element.items()))
+                self.update({element.tag: aDict})
+            # this assumes that if you've got an attribute in a tag,
+            # you won't be having any text. This may or may not be a
+            # good idea -- time will tell. It works for the way we are
+            # currently doing XML configuration files...
+            elif element.items():
+                self.update({element.tag: dict(element.items())})
+            # finally, if there are no child tags and no attributes, extract
+            # the text
+            else:
+                self.update({element.tag: element.text})
+
+
+def xml2dict(xml_filename):
+    tree = ElementTree.parse(xml_filename)
+    root = tree.getroot()
+    xml_dict = XmlDictConfig(root)
+    return xml_dict
+
+
+def xml2list(xml_filename):
+    tree = ElementTree.parse(xml_filename)
+    root = tree.getroot()
+    xml_list = XmlListConfig(root)
+    return xml_list


### PR DESCRIPTION
- moved `utils.py` to `utils/__init__.py`
- added `utils/xml2x.py` (self explanatory) with test (`tests/*xml*`)

This will help easily parse xml-based datasets (e.g. PASCAL VOC, ImageNet, etc.).
