### PR TITLE
make datasets-* scripts work and get installed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,7 @@ Programs
 datasets-fetch
 -------------
 
-Usage: ``dataset-fetch <dataset_name>``
+Usage: ``datasets-fetch <dataset_name>``
 
 This program downloads the named dataset into the ``$SCIKITS_DATA`` directory.
 Typically this means downloading from original sources online.
@@ -137,7 +137,7 @@ To see more about how sub-modules use this mechanism, grep the code for ``main_f
 datasets-show
 -------------
 
-Usage: ``dataset-show <dataset_name>``
+Usage: ``datasets-show <dataset_name>``
 
 This program downloads the named dataset if necessary into the ``$SCIKITS_DATA`` directory,
 loads it, and launches a simple GUI program to visualize the elements of the
@@ -147,7 +147,7 @@ To see more about how sub-modules use this mechanism, grep the code for ``main_s
 datasets-erase
 -------------
 
-Usage: ``dataset-erase <dataset_name>``
+Usage: ``datasets-erase <dataset_name>``
 
 This program erases any data cached or downloaded in support of the named dataset.
 To see more about how sub-modules use this mechanism, grep the code for ``main_erase``.

--- a/bin/datasets-clean-up
+++ b/bin/datasets-clean-up
@@ -5,5 +5,5 @@ logging.basicConfig(
         stream=sys.stderr,
         level=logging.INFO)
 
-import datasets.main
-datasets.main.main('erase')
+import skdata.main
+skdata.main.main('erase')

--- a/bin/datasets-fetch
+++ b/bin/datasets-fetch
@@ -5,5 +5,5 @@ logging.basicConfig(
         stream=sys.stderr,
         level=logging.INFO)
 
-import datasets.main
-datasets.main.main('fetch')
+import skdata.main
+skdata.main.main('fetch')

--- a/bin/datasets-show
+++ b/bin/datasets-show
@@ -5,5 +5,5 @@ logging.basicConfig(
         stream=sys.stderr,
         level=logging.INFO)
 
-import datasets.main
-datasets.main.main('show')
+import skdata.main
+skdata.main.main('show')

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ descr = """A collection of datasets available and associated tools"""
 import sys
 import os
 import shutil
+import glob
 
 DISTNAME = 'skdata'
 DESCRIPTION = ''
@@ -68,6 +69,7 @@ if __name__ == "__main__":
           long_description=LONG_DESCRIPTION,
           zip_safe=True,  # the package can run out of an .egg file
           install_requires=['numpy>=1.3.0'], # 'glumpy>=0.1.0'
+          scripts=glob.glob(os.path.join("bin","*")),
           classifiers=[
               'Intended Audience :: Science/Research',
               'Intended Audience :: Developers',

--- a/skdata/main.py
+++ b/skdata/main.py
@@ -53,6 +53,6 @@ def main(cmd):
         logger.error('Module name required (XXX: print Usage)')
         return 1
 
-    symbol = load_tokens(['datasets'] + argv1.split('.') + [runner])
+    symbol = load_tokens(['skdata'] + argv1.split('.') + [runner])
     logger.info('running: %s' % str(symbol))
     sys.exit(symbol())


### PR DESCRIPTION
also updated README to reflect current (plural) name of the datasets-*
scripts.

now setup.py install installs the datasets-\* scripts, so one can start using them. These needed to be updated, since they were still referring to datasets. Not all datasets work this way, but it's a step forward
