### PR TITLE
RFC: Dslang

### DIFF
--- a/skdata/dslang.py
+++ b/skdata/dslang.py
@@ -1,0 +1,75 @@
+"""
+
+AST elements of a DSL for describing cross-validation experiment protocols.
+
+"""
+
+class Average(object):
+    def __init__(self, values):
+        self.values = values
+
+
+class Score(object):
+    def __init__(self, model, task):
+        self.model = model
+        self.task = task
+
+
+class BestModel(object):
+    def __init__(self, split):
+        self.split = split
+
+
+class MergeTasks(object):
+    def __init__(self, *tasks):
+        self.tasks = tasks
+
+
+class RetrainClassifier(object):
+    def __init__(self, model, task):
+        self.model = model
+        self.task = task
+
+
+#
+#lfw_official = Average([
+#    (Score(RetrainClassifier(BestModel(v1), s.train), s.test)
+#    for s in v2.splits])
+#
+#lfw_more_data = AverageTestScore([(BestModel(MergeTasks(s.train, v1.train, v1.test))
+#    for s in v2.splits])
+#
+
+import numpy as np
+
+class Visitor(object):
+
+    def evaluate(self, node, memo):
+        if memo is None:
+            memo = {}
+
+        if id(node) not in memo:
+            fname = 'on_' + node.__class__.__name__
+            rval = getattr(self, fname)(node, memo)
+            memo[node] = rval
+
+        return memo[node]
+
+    def on_Average(self, node, memo):
+        return np.mean([self.evaluate(value, memo) for value in node.values])
+
+    def on_Score(self, node, memo):
+        model = self.evaluate(node.model, memo)
+        task = self.evaluate(node.task, memo)
+        raise NotImplementedError('implement me')
+
+    def on_BestModel(self, node, memo):
+        split = self.evaluate(node.split, memo)
+        raise NotImplementedError('implement me')
+
+    def on_Task(self, node, memo):
+        return node
+
+    def on_Split(self, node, memo):
+        return node
+

--- a/skdata/iris/views.py
+++ b/skdata/iris/views.py
@@ -5,9 +5,11 @@ Experiment views on the Iris data set.
 
 import numpy as np
 from sklearn import cross_validation
+
 from .dataset import Iris
 from ..base import Task, Split
 from ..utils import int_labels
+from ..dslang import Average, Score, BestModel
 
 
 class KfoldClassification(object):
@@ -51,4 +53,7 @@ class KfoldClassification(object):
                         x=self.x[idxmap[test_idxs]],
                         y=self.y[idxmap[test_idxs]]),
                     ))
+
+
+        self.dsl = Average([Score(BestModel(s.train), s.test) for s in self.splits])
 

--- a/skdata/tests/test_dslang.py
+++ b/skdata/tests/test_dslang.py
@@ -1,0 +1,34 @@
+from ..dslang import Visitor
+from ..iris.views import KfoldClassification
+import sklearn.linear_model
+
+
+class SVMAlgo(Visitor):
+    def __init__(self, model_factory):
+        self.model_factory = model_factory
+
+    def on_BestModel(self, node, memo):
+        train = self.evaluate(node.split, memo)
+        model = self.model_factory()
+        model.fit(train.x, train.y)
+        return model
+
+    def on_Score(self, node, memo):
+        model = self.evaluate(node.model, memo)
+        task = self.evaluate(node.task, memo)
+        y_pred = model.predict(task.x)
+        return (y_pred == task.y).mean()
+
+def test_dslang():
+    kfc = KfoldClassification(2, y_as_int=True)
+
+    def new_model():
+        return sklearn.linear_model.SGDClassifier()
+
+    memo = {}
+    dsl = kfc.dsl
+    SVMAlgo(new_model).evaluate(dsl, memo)
+
+    print 'final score', memo[dsl]
+
+


### PR DESCRIPTION
@npinto @poilvert 

What do you think of this DSL to formalize experiment evaluation protocols?  As you can see, it's optional... all the tasks & views & splits etc. that we've been talking about are still there unmodified, there's just a "dsl" attribute at the top level that formally specifies what the user is _supposed_ to do.  Maybe for performance reasons the user might not want to implement is learning algorithm as a visitor (as I showed in test_dslang) but at least for unit testing purposes this specifies exactly what the right answer is, even if the user wants to compute it some other way.
