### PR TITLE
More changes to enable support for py3k.

### DIFF
--- a/skdata/cifar10/dataset.py
+++ b/skdata/cifar10/dataset.py
@@ -14,7 +14,7 @@ http://www.cs.toronto.edu/~kriz/learning-features-2009-TR.pdf
 # License: BSD 3 clause
 
 import os
-import cPickle
+import pickle
 import logging
 import shutil
 
@@ -127,8 +127,8 @@ class CIFAR10(object):
     def unpickle(self, basename):
         fname = self.home('cifar-10-batches-py', basename)
         logger.info('loading file %s' % fname)
-        fo = open(fname, 'rb')
-        data = cPickle.load(fo)
-        fo.close()
-        return data
-
+        with open(fname, 'rb') as fo:
+            try:
+                return pickle.load(fo, encoding='latin1')
+            except:
+                return pickle.load(fo)

--- a/skdata/utils/__init__.py
+++ b/skdata/utils/__init__.py
@@ -1,9 +1,9 @@
 from .dotdict import *
 from .image import *
 
-from my_path import get_my_path, get_my_path_basename
-from xml2x import xml2dict, xml2list
-from download_and_extract import download, extract, download_and_extract
+from .my_path import get_my_path, get_my_path_basename
+from .xml2x import xml2dict, xml2list
+from .download_and_extract import download, extract, download_and_extract
 
 
 # -- old utils.py

--- a/skdata/utils/download_and_extract.py
+++ b/skdata/utils/download_and_extract.py
@@ -8,7 +8,7 @@ from urllib2 import urlopen
 from os import path
 import hashlib
 
-import archive
+from . import archive
 
 
 def verify_sha1(filename, sha1):


### PR DESCRIPTION
This PR includes a pickling trick to be able to load numpy files pickled in py2k, as well as package-relative imports.