### PR TITLE
Python 3 Compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
         try:
             sys.stdout = StringIO()  # supress noisy output
             res = lib2to3.main.main("lib2to3.fixes",
-                                    ['-x', 'import', '-w', local_path])
+                                    ['-w', local_path])
         finally:
             sys.stdout = _old_stdout
 

--- a/skdata/toy.py
+++ b/skdata/toy.py
@@ -7,8 +7,8 @@ import os
 
 import numpy as np
 
-import utils
-import utils.image
+from utils import image
+
 
 class BuildOnInit(object):
     """Base class that calls build_meta and build_all
@@ -147,6 +147,5 @@ class SampleImages(BuildOnInit):
                 {})
 
     def images(self):
-        return map(
-                utils.image.load_rgb_f32,
-                map( lambda m: self.fullpath(m['filename']), self.meta))
+        return map(image.load_rgb_f32,
+                   map(lambda m: self.fullpath(m['filename']), self.meta))


### PR DESCRIPTION
Some fixes necessary to get the hyperopt-sklearn tests running on Python 3.4.