### PR TITLE
Fix print statements for python3 compatability in base and MNIST and remove whitespace

### DIFF
--- a/skdata/base.py
+++ b/skdata/base.py
@@ -219,7 +219,7 @@ class SklearnClassifier(SemanticsDelegator):
     def best_model_vector_classification(self, train, valid):
         # TODO: use validation set if not-None
         model = self.new_model()
-        print 'SklearnClassifier training on data set of shape', train.x.shape
+        print('SklearnClassifier training on data set of shape', train.x.shape)
         model.fit(train.x, train.y)
         model.trained_on = train.name
         self.results['best_model'].append(
@@ -288,5 +288,3 @@ class SklearnClassifier(SemanticsDelegator):
     def loss_indexed_image_classification(self, model, task):
         return self.loss_vector_classification(model,
             self._fallback_indexed_image_task(task))
-
-

--- a/skdata/mnist/dataset.py
+++ b/skdata/mnist/dataset.py
@@ -85,12 +85,12 @@ def _read_header(f, debug=False, fromgzip=None):
     if magic in (2049, 2051):
         logger.info('Reading on big-endian machine.')
         endian = 'big'
-        next_int32 = lambda : _read_int32(f)
+        next_int32 = lambda: _read_int32(f)
     elif _reverse_bytes_int32(magic) in (2049, 2051):
         logger.info('Reading on little-endian machine.')
         magic = _reverse_bytes_int32(magic)
         endian = 'little'
-        next_int32 = lambda : _reverse_bytes_int32(_read_int32(f))
+        next_int32 = lambda: _reverse_bytes_int32(_read_int32(f))
     else:
         raise IOError('MNIST data file appears to be corrupt')
 
@@ -169,7 +169,7 @@ class MNIST(object):
                 if download_if_missing:
                     logger.warn("Downloading %s %s: %s => %s" % (
                         FILE_SIZES_PRETTY[role], role, url, dest))
-                    downloader = urllib.urlopen(url)
+                    downloader = urllib.request.urlopen(url)
                     data = downloader.read()
                     tmp = open(dest, 'wb')
                     tmp.write(data)
@@ -202,9 +202,9 @@ class MNIST(object):
         assert len(arrays['train_images']) == len(arrays['train_labels'])
         assert len(arrays['test_images']) == len(arrays['test_labels'])
         meta = [dict(id=i, split='train', label=l)
-                for i,l in enumerate(arrays['train_labels'])]
+                for i, l in enumerate(arrays['train_labels'])]
         i = len(meta)
         meta.extend([dict(id=i + j + 1, split='test', label=l)
-                for j, l in enumerate(arrays['test_labels'])])
+                    for j, l in enumerate(arrays['test_labels'])])
         assert len(meta) == 70000, (i, len(meta))
         return meta

--- a/skdata/mnist/dataset.py
+++ b/skdata/mnist/dataset.py
@@ -49,6 +49,7 @@ FILE_SIZES_PRETTY = dict(
     test_labels='4.5K',
     )
 
+
 def _read_int32(f):
     """unpack a 4-byte integer from the current position in file f"""
     s = f.read(4)
@@ -207,4 +208,3 @@ class MNIST(object):
                 for j, l in enumerate(arrays['test_labels'])])
         assert len(meta) == 70000, (i, len(meta))
         return meta
-

--- a/skdata/mnist/main.py
+++ b/skdata/mnist/main.py
@@ -45,22 +45,20 @@ def main_clean_up():
     MNIST().clean_up()
 
 
-
 def main():
     logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
     if len(sys.argv) <= 1:
-        print usage
+        print(usage)
         return 1
     else:
         try:
             fn = globals()['main_' + sys.argv[1]]
         except:
-            print 'command %s not recognized' % sys.argv[1]
-            print usage
+            print('command %s not recognized' % sys.argv[1])
+            print(usage)
             return 1
         return fn()
 
 
 if __name__ == '__main__':
     sys.exit(main())
-

--- a/skdata/mnist/tests/test_dataset.py
+++ b/skdata/mnist/tests/test_dataset.py
@@ -12,4 +12,3 @@ def test_MNIST():
     assert M.meta[69999] == dict(id=69999, split='test', label=6), M.meta[69999]
     assert len(M.meta) == 70000
 
-


### PR DESCRIPTION
These additions are backwards compatible with python2 and do not affect the functionality of the code